### PR TITLE
#19 remove cql create and add compact option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ which has since been deprecated ([CASSANDRA-9618](https://issues.apache.org/jira
 and has since been entirely removed with plans to add a replacement ([CASSANDRA-7464](https://issues.apache.org/jira/browse/CASSANDRA-7464)).
 
 A key differentiator between the storage format between older verisons of
-Cassandra and Cassandra 3.0 is that an SSTable was previously a representation 
+Cassandra and Cassandra 3.0 is that an SSTable was previously a representation
 of partitions and their cells (identified by their clustering and column
 name) whereas with Cassandra 3.0 an SSTable now represents partitions and their
 rows.  You can read about these changes in more detail by visiting
@@ -55,11 +55,10 @@ should be much more pleasant to follow.
 ```
 java -jar sstable-tools.jar toJson
 
-usage: toJson <sstable> [-c <arg>] [-e] [-k <arg>] [-x <arg>]
+usage: toJson <sstable> [-c] [-e] [-k <arg>] [-x <arg>]
 
 Converts SSTable into a JSON formatted document.
-  -c <arg> Optional file containing "CREATE TABLE..." for the sstable's schema.  Used to determine the partition and
-           clustering key names. Must not include "keyspace." in create statement.  If not included will not print key names.
+  -c       Print one partition per line.
   -e       Only print out the keys for the sstable.  If enabled other options are ignored.
   -k <arg> Partition key to be included.  May be used multiple times.  If not set will default to all keys.
   -x <arg> Partition key to be excluded.  May be used multiple times.
@@ -74,18 +73,12 @@ series of rows with columns:
 [
   {
     "partition" : {
-      "key" : [
-        { "name" : "symbol", "value" : "YYY0" },
-        { "name" : "year", "value" : "1994" }
-      ]
+      "key" : [ "YYY0", "1994" ]
     },
     "rows" : [
       {
         "type" : "row",
-        "clustering" : [
-          { "name" : "month", "value" : "12" },
-          { "name" : "day", "value" : "30" }
-        ],
+        "clustering" : [ "12", "30" ],
         "cells" : [
           { "name" : "close", "value" : "11.5", "tstamp" : 1449469421746061 },
           { "name" : "open", "value" : "12.5", "tstamp" : 1449469421746061 },
@@ -94,10 +87,7 @@ series of rows with columns:
       },
       {
         "type" : "row",
-        "clustering" : [
-          { "name" : "month", "value" : "12" },
-          { "name" : "day", "value" : "29" }
-        ],
+        "clustering" : [ "12", "29" ],
         "cells" : [
           { "name" : "close", "value" : "12.75", "tstamp" : 1449469421746060 },
           { "name" : "high", "value" : "13.0", "tstamp" : 1449469421746060 },
@@ -110,18 +100,12 @@ series of rows with columns:
   },
   {
     "partition" : {
-      "key" : [
-        { "name" : "symbol", "value" : "AAAA" },
-        { "name" : "year", "value" : "2016" }
-      ]
+      "key" : [ "AAAA", "2016"]
     },
     "rows" : [
       {
         "type" : "row",
-        "clustering" : [
-          { "name" : "month", "value" : "12" },
-          { "name" : "day", "value" : "13" }
-        ],
+        "clustering" : [ "12", "13" ],
         "liveness_info" : { "tstamp" : 1450034993891342, "ttl" : 10000, "expires_at" : 1450044993, "expired" : false },
         "cells" : [
           { "name" : "close", "value" : "100.0" },
@@ -136,155 +120,15 @@ series of rows with columns:
 ]
 ```
 
-An example demonstrating what output will look like if you do not provide a CQL
-schema via `-c`.  Partition and Clustering key column names are simply omitted
-and only their values are provided:
-
-
-```json
-[
-  {
-    "partition" : {
-      "key" : [ "ZLC", "2003" ]
-    },
-    "rows" : [
-      {
-        "type" : "row",
-        "clustering" : [ "12", "31" ],
-        "cells" : [
-          { "name" : "close", "value" : "53.2", "tstamp" : 1449469421557041 },
-          { "name" : "high", "value" : "53.48", "tstamp" : 1449469421557041 },
-          { "name" : "low", "value" : "52.56", "tstamp" : 1449469421557041 },
-          { "name" : "open", "value" : "53.35", "tstamp" : 1449469421557041 },
-          { "name" : "volume", "value" : "93600", "tstamp" : 1449469421557041 }
-        ]
-      }
-    ]
-  }
-]
-```
-
-
 An example showing an SSTable with tombstones at all levels:
 
 A partition, its rows and its columns can also have
 [tombstones](http://docs.datastax.com/en/cassandra/2.0/cassandra/dml/dml_about_deletes_c.html)
-which represent deletes.  In Cassandra 3.0, users can now delete ranges of 
+which represent deletes.  In Cassandra 3.0, users can now delete ranges of
 rows ([CASSANDRA-6237](https://issues.apache.org/jira/browse/CASSANDRA-6237))
 which creates range tombstones.
 
 
 ```json
-[
-  {
-    "partition" : {
-      "key" : [
-        { "name" : "symbol", "value" : "CORP" },
-        { "name" : "year", "value" : "2006" }
-      ],
-      "deletion_info" : { "deletion_time" : 1449967308857460, "tstamp" : 1449967308 }
-    }
-  },
-  {
-    "partition" : {
-      "key" : [
-        { "name" : "symbol", "value" : "CORP" },
-        { "name" : "year", "value" : "2004" }
-      ]
-    },
-    "rows" : [
-      {
-        "type" : "range_tombstone_bound",
-        "start" : {
-          "type" : "inclusive",
-          "clustering" : [
-            { "name" : "month", "value" : "4" },
-            { "name" : "day", "value" : "*" }
-          ],
-          "deletion_info" : { "deletion_time" : 1449958944345632, "tstamp" : 1449958944 }
-        }
-      },
-      {
-        "type" : "range_tombstone_bound",
-        "end" : {
-          "type" : "inclusive",
-          "clustering" : [
-            { "name" : "month", "value" : "4" },
-            { "name" : "day", "value" : "*" }
-          ],
-          "deletion_info" : { "deletion_time" : 1449958944345632, "tstamp" : 1449958944 }
-        }
-      },
-      {
-        "type" : "row",
-        "clustering" : [
-          { "name" : "month", "value" : "3" },
-          { "name" : "day", "value" : "16" }
-        ],
-        "cells" : [
-          { "name" : "high", "value" : "100.0", "ttl" : 144000, "deletion_time" : 1450103151, "expired" : false, "tstamp" : 1449959151499921 }
-        ]
-      },
-      {
-        "type" : "row",
-        "clustering" : [
-          { "name" : "month", "value" : "3" },
-          { "name" : "day", "value" : "14" }
-        ],
-        "cells" : [
-          { "name" : "open", "deletion_time" : 1449958979, "tstamp" : 1449958979852772 }
-        ]
-      },
-      {
-        "type" : "row",
-        "clustering" : [
-          { "name" : "month", "value" : "3" },
-          { "name" : "day", "value" : "12" }
-        ],
-        "deletion_info" : { "deletion_time" : 1449958958765226, "tstamp" : 1449958958 }
-      },
-      {
-        "type" : "range_tombstone_bound",
-        "start" : {
-          "type" : "exclusive",
-          "clustering" : [
-            { "name" : "month", "value" : "2" },
-            { "name" : "day", "value" : "12" }
-          ],
-          "deletion_info" : { "deletion_time" : 1449961223094378, "tstamp" : 1449961223 }
-        }
-      },
-      {
-        "type" : "range_tombstone_boundary",
-        "start" : {
-          "type" : "exclusive",
-          "clustering" : [
-            { "name" : "month", "value" : "2" },
-            { "name" : "day", "value" : "7" }
-          ],
-          "deletion_info" : { "deletion_time" : 1449961214148839, "tstamp" : 1449961214 }
-        },
-        "end" : {
-          "type" : "inclusive",
-          "clustering" : [
-            { "name" : "month", "value" : "2" },
-            { "name" : "day", "value" : "7" }
-          ],
-          "deletion_info" : { "deletion_time" : 1449961223094378, "tstamp" : 1449961223 }
-        }
-      },
-      {
-        "type" : "range_tombstone_bound",
-        "end" : {
-          "type" : "exclusive",
-          "clustering" : [
-            { "name" : "month", "value" : "2" },
-            { "name" : "day", "value" : "3" }
-          ],
-          "deletion_info" : { "deletion_time" : 1449961214148839, "tstamp" : 1449961214 }
-        }
-      }
-    ]
-  }
-]
+TODO - update with loss of cql create option
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <version>3.0.0-SNAPSHOT</version>
   <name>SSTable Tools</name>
   <properties>
-    <cassandra.version>3.0.0</cassandra.version>
+    <cassandra.version>3.1.1</cassandra.version>
     <powermock.version>1.6.4</powermock.version>
     <junit.version>4.6</junit.version>
     <logback.version>1.1.3</logback.version>

--- a/src/main/java/com/csforge/sstable/Driver.java
+++ b/src/main/java/com/csforge/sstable/Driver.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 public class Driver {
     public static void main(String ... args) {
-        ((LoggerContext) LoggerFactory.getILoggerFactory()).stop();
         if (args.length == 0) {
             printCommands();
             System.exit(-1);

--- a/src/main/java/com/csforge/sstable/JsonTransformer.java
+++ b/src/main/java/com/csforge/sstable/JsonTransformer.java
@@ -33,29 +33,23 @@ public final class JsonTransformer {
 
     private final JsonGenerator json;
 
-    private final CompactIndenter objectIndenter;
+    private final CompactIndenter objectIndenter = new CompactIndenter();
 
-    private final CompactIndenter arrayIndenter;
+    private final CompactIndenter arrayIndenter = new CompactIndenter();
 
-    private final CompactIndenter compactIndenter;
+    private final CompactIndenter partitionIndenter = new CompactIndenter("", "", System.lineSeparator());
 
     private final CFMetaData metadata;
-
-    private final boolean compact;
 
     private JsonTransformer(JsonGenerator json, CFMetaData metadata, boolean compact) {
         this.json = json;
         this.metadata = metadata;
-        this.compact = compact;
-        objectIndenter = new CompactIndenter();
-        arrayIndenter = new CompactIndenter();
-        compactIndenter = new CompactIndenter("", "", System.lineSeparator());
 
         DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
         if(compact) {
-            compactIndenter.setCompact(false);
-            prettyPrinter.indentObjectsWith(compactIndenter);
-            prettyPrinter.indentArraysWith(compactIndenter);
+            partitionIndenter.setCompact(false);
+            prettyPrinter.indentObjectsWith(partitionIndenter);
+            prettyPrinter.indentArraysWith(partitionIndenter);
         } else {
             prettyPrinter.indentObjectsWith(objectIndenter);
             prettyPrinter.indentArraysWith(arrayIndenter);
@@ -131,9 +125,9 @@ public final class JsonTransformer {
     private void serializePartition(Partition partition) {
         String key = metadata.getKeyValidator().getString(partition.getKey().getKey());
         try {
-            compactIndenter.setCompact(false);
+            partitionIndenter.setCompact(false);
             json.writeStartObject();
-            compactIndenter.setCompact(true);
+            partitionIndenter.setCompact(true);
 
             json.writeFieldName("partition");
 
@@ -172,7 +166,7 @@ public final class JsonTransformer {
 
             json.writeEndObject();
 
-            compactIndenter.setCompact(false);
+            partitionIndenter.setCompact(false);
         } catch (IOException e) {
             logger.error("Fatal error parsing partition: {}", key, e);
         }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,12 +1,12 @@
 <configuration>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <root level="debug">
-    <appender-ref ref="STDOUT" />
+  <root level="error">
+    <appender-ref ref="STDERR" />
   </root>
 </configuration>


### PR DESCRIPTION
- add compact -c option to print partition per line
- remove the cql option to have single output (easier for json2sstable)
- use logback again
