### PR TITLE
Offline Select 'cqlsh'-style console mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,72 @@ Pre compiled binary available from bintray:
 
 * [sstable-tools-3.0.0-alpha2.jar](https://bintray.com/artifact/download/tolbertam/sstable-tools/sstable-tools-3.0.0-alpha2.jar) -  Currently tested with 3.0, 3.1, 3.1.1, 3.2.1, 3.3.
 
-Example Usage:
+Example usage:
 
     java -jar sstable-tools-3.0.0-alpha2.jar toJson ma-2-big-Data.db
+    java -jar sstable-tools-3.0.0-alpha2.jar describe ma-2-big-Data.db
     java -jar sstable-tools-3.0.0-alpha3.jar SELECT count(*) FROM ma-2-big-Data.db WHERE age > 30  (TODO: Escape this as it doesnt work as is.)
+    
+Example shell usage:
 
+    java -jar sstable-tools-3.0.0-alpha2.jar cqlsh
+    
+    ## Select one or more (space delimited, or choose directory to include all)
+    cqlsh> use ma-2-big-Data.db;
+    
+    ## Use create table statement to set the schema (can view with 'describe schema'). This is optional but without
+    ## it the partition key and clustering index names are unknown.
+    cqlsh> CREATE TABLE users (
+    ...        user_name varchar PRIMARY KEY,
+    ...        password varchar,
+    ...        gender varchar,
+    ...        state varchar,
+    ...        birth_year bigint
+    ...    );
+    
+    ## Discover the data in sstable(s) using CQL queries
+    cqlsh> SELECT * FROM sstable WHERE age > 1 LIMIT 1
+    
+     ┌────────────┬─────────────┬─────────┬───────────┬────────┐
+     │user_name   │birth_year   │gender   │password   │state   │
+     ╞════════════╪═════════════╪═════════╪═══════════╪════════╡
+     │frodo       │1985         │male     │pass@      │CA      │
+     └────────────┴─────────────┴─────────┴───────────┴────────┘
+    
+    ## Display raw sstable data (useful to see tombstones and expired ttls) with optional where clause
+    cqlsh> DUMP WHERE age > 1 LIMIT 1
+    [frodo] Row[info=[ts=1455937221199050] ]:  | [birth_year=1985 ts=1455937221199050], [gender=male ts=1455937221199050], [password=pass@ ts=1455937221199050], [state=CA ts=1455937221199050]
+    
+    ## Describe the sstable data and metadata
+    cqlsh> describe sstables;
+    
+    /Users/clohfink/git/sstable-tools/./src/test/resources/ma-2-big-Data.db
+    =======================================================================
+    Partitions: 1
+    Rows: 1
+    Tombstones: 0
+    Cells: 4
+    Widest Partitions:
+       [frodo] 1
+    Largest Partitions:
+       [frodo] 104 (104 B)
+    Tombstone Leaders:
+    Partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+    Bloom Filter FP chance: 0.010000
+    Size: 50 (50 B) 
+    Compressor: org.apache.cassandra.io.compress.LZ4Compressor
+      Compression ratio: -1.0
+    Minimum timestamp: 1455937221199050 (02/19/2016 21:00:21)
+    Maximum timestamp: 1455937221199050 (02/19/2016 21:00:21)
+    SSTable min local deletion time: 2147483647 (01/18/2038 21:14:07)
+    SSTable max local deletion time: 2147483647 (01/18/2038 21:14:07)
+    TTL min: 0 (0 milliseconds)
+    ...[snip]...
+    
+>>>>>>> update readme a little
 **Note:** No environment configuration is necessary for this tool to work if all components of the sstable are available but the cql create statement allows for more details.
 
-**Note:** CQL statements require bash escaping, future interactive mode should make this easier ([#30](https://github.com/tolbertam/sstable-tools/issues/30))
+**Note:** CQL statements require bash escaping when using the "select" command via command line ```java -jar sstable-tools.jar select \* from \"path\"```
 
 
 see more below
@@ -35,6 +93,32 @@ mvn package
 ```
 
 The executable jar will be present in the target directory.
+
+## cqlsh
+cql shell similiar and modeled after the C* cqlsh tool. This will allow issuing cql queries against raw sstables and
+providing additional diagnostic tools over them. Provides history (reverse searchable with ctrl-r) for ease of use.
+
+```text
+EXIT              - leaves the shell (also ctrl-d on prompt, ctrl-c to break back to blank prompt)
+CREATE TABLE ...  - A CREATE TABLE cql statement to use as metadata when reading sstables (HIGHLY RECOMMENDED!)
+DESCRIBE SCHEMA   - Show currently used schema (or serialized cfmetadata if generated)
+DESCRIBE SSTABLES - Provide details and statistics on current sstable(s)
+USE               - update the sstable[s] used by default with select, dump, describe commands
+    USE /var/lib/cassandra/data/system/peers/ma-1-big-Data.db
+    or with multiple sstables separated with spaces. This can also be a directory which will add all sstables in it.
+    USE ma-1-big-Data.db ma-2-big-Data.db "/home/path with space/db/data/sstables"
+
+SELECT            - run a cql query against the current sstable (unless other specified)
+    SELECT * FROM sstables WHERE key > 1 LIMIT 10
+    the keyword sstables will use the current sstable set with the USE command or set when running cqlsh. You can also
+    specify an sstable here
+    SELECT avg(someColumn) FROM /var/lib/cassandra/data/system/peers/ma-1-big-Data.db WHERE key > 1
+
+DUMP              - dump the raw unfiltered partitions/rows. Useful for debuging TTLed/tombstoned data.
+    DUMP;
+    Can also specify a where clause for filtering the results.
+    DUMP WHERE partitionKey = 'OpsCenter';
+```
 
 ## sstable2json
 
@@ -135,7 +219,7 @@ which creates range tombstones.
 
 
 ```json
-TODO - update with loss of cql create option
+TODO: update with loss of cql create option
 ```
 
 ## select

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,20 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.4.0</version>
+        <configuration>
+          <mainClass>com.csforge.sstable.Driver</mainClass>
+          <arguments>
+            <argument>
+              cqlsh
+            </argument>
+          </arguments>
+          <cleanupDaemonThreads>false</cleanupDaemonThreads>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <logback.version>1.1.3</logback.version>
     <slf4j.version>1.7.13</slf4j.version>
     <jackson.version>2.6.4</jackson.version>
+    <jline.version>2.13</jline.version>
   </properties>
   <dependencies>
     <dependency>
@@ -60,6 +61,11 @@
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
       <version>${powermock.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
+      <version>${jline.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>jline</artifactId>
       <version>${jline.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>1.3.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/csforge/sstable/CassandraUtils.java
+++ b/src/main/java/com/csforge/sstable/CassandraUtils.java
@@ -69,26 +69,29 @@ public class CassandraUtils {
 
     public static CFMetaData tableFromBestSource(File sstablePath) throws IOException, NoSuchFieldException, IllegalAccessException {
         // TODO add CQL/Thrift mechanisms as well
-        String cqlPath = System.getProperty("sstabletools.schema");
-        InputStream in;
-        if (!Strings.isNullOrEmpty(cqlPath)) {
-            in = new FileInputStream(cqlPath);
-        } else {
-            in = Query.class.getClassLoader().getResourceAsStream("schema.cql");
-            if (in == null && new File("schema.cql").exists()) {
-                in = new FileInputStream("schema.cql");
-            }
-        }
+
         CFMetaData metadata;
         if (cqlOverride != null) {
             logger.debug("Using override metadata");
             metadata = CassandraUtils.tableFromCQL(new ByteArrayInputStream(cqlOverride.getBytes()));
-        } else if (in == null) {
-            logger.debug("Using metadata from sstable");
-            metadata = CassandraUtils.tableFromSSTable(sstablePath);
         } else {
-            logger.debug("Using metadata from CQL schema in " + cqlPath);
-            metadata = CassandraUtils.tableFromCQL(in);
+            String cqlPath = System.getProperty("sstabletools.schema");
+            InputStream in;
+            if (!Strings.isNullOrEmpty(cqlPath)) {
+                in = new FileInputStream(cqlPath);
+            } else {
+                in = Query.class.getClassLoader().getResourceAsStream("schema.cql");
+                if (in == null && new File("schema.cql").exists()) {
+                    in = new FileInputStream("schema.cql");
+                }
+            }
+            if (in == null) {
+                logger.debug("Using metadata from sstable");
+                metadata = CassandraUtils.tableFromSSTable(sstablePath);
+            } else {
+                logger.debug("Using metadata from CQL schema in " + cqlPath);
+                metadata = CassandraUtils.tableFromCQL(in);
+            }
         }
         return metadata;
     }

--- a/src/main/java/com/csforge/sstable/CassandraUtils.java
+++ b/src/main/java/com/csforge/sstable/CassandraUtils.java
@@ -1,7 +1,13 @@
 package com.csforge.sstable;
 
+import com.csforge.sstable.reader.CassandraReader;
+import com.csforge.sstable.reader.Partition;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.collect.Sets;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Files;
 import org.apache.cassandra.config.CFMetaData;
@@ -15,29 +21,44 @@ import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UserType;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
+import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.io.compress.CompressionMetadata;
+import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
-import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
-import org.apache.cassandra.io.sstable.metadata.MetadataType;
-import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.metadata.*;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.*;
 import org.apache.cassandra.utils.FBUtilities;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+import org.joda.time.ReadableDuration;
+import org.joda.time.format.PeriodFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class CassandraUtils {
     private static final Logger logger = LoggerFactory.getLogger(CassandraUtils.class);
     private static final AtomicInteger cfCounter = new AtomicInteger();
+    public static Map<String, UserType> knownTypes = Maps.newHashMap();
+    public static String cqlOverride = null;
 
     static {
         Config.setClientMode(true);
@@ -59,12 +80,15 @@ public class CassandraUtils {
             in = new FileInputStream(cqlPath);
         } else {
             in = Query.class.getClassLoader().getResourceAsStream("schema.cql");
-            if (in == null) {
+            if (in == null && new File("schema.cql").exists()) {
                 in = new FileInputStream("schema.cql");
             }
         }
         CFMetaData metadata;
-        if (in == null) {
+        if (cqlOverride != null){
+            logger.debug("Using override metadata");
+            metadata = CassandraUtils.tableFromCQL(new ByteArrayInputStream(cqlOverride.getBytes()));
+        } else if (in == null) {
             logger.debug("Using metadata from sstable");
             metadata = CassandraUtils.tableFromSSTable(sstablePath);
         } else {
@@ -72,6 +96,14 @@ public class CassandraUtils {
             metadata = CassandraUtils.tableFromCQL(in);
         }
         return metadata;
+    }
+
+    private static Types getTypes() {
+        if(knownTypes.isEmpty()) {
+            return Types.none();
+        } else {
+            return Types.of(knownTypes.values().toArray(new UserType[0]));
+        }
     }
 
     public static CFMetaData tableFromCQL(InputStream source) throws IOException {
@@ -87,7 +119,7 @@ public class CassandraUtils {
         statement.prepareKeyspace(keyspace);
 
         Schema.instance.setKeyspaceMetadata(KeyspaceMetadata.create(keyspace, KeyspaceParams.local(), Tables.none(),
-                Views.none(), Types.none(), Functions.none()));
+                Views.none(), getTypes(), Functions.none()));
         return ((CreateTableStatement) statement.prepare().statement).getCFMetaData();
     }
 
@@ -95,6 +127,12 @@ public class CassandraUtils {
         Field type = obj.getClass().getDeclaredField(name);
         type.setAccessible(true);
         return type.get(obj);
+    }
+
+    public static Object callPrivate(Object obj, String name) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method m = obj.getClass().getDeclaredMethod(name);
+        m.setAccessible(true);
+        return m.invoke(obj);
     }
 
     @SuppressWarnings("unchecked")
@@ -130,7 +168,235 @@ public class CassandraUtils {
         }
         CFMetaData metaData = builder.build();
         Schema.instance.setKeyspaceMetadata(KeyspaceMetadata.create(metaData.ksName, KeyspaceParams.local(),
-                Tables.of(metaData), Views.none(), Types.none(), Functions.none()));
+                Tables.of(metaData), Views.none(), getTypes(), Functions.none()));
         return metaData;
+    }
+
+    public static <T> Stream<T> asStream(Iterator<T> iter)
+    {
+        Spliterator<T> splititer = Spliterators.spliteratorUnknownSize(iter, Spliterator.IMMUTABLE);
+        return StreamSupport.stream(splititer, false);
+    }
+
+    public static String wrapQuiet(String toWrap, boolean color) {
+        StringBuilder sb = new StringBuilder();
+        if(color) {
+            sb.append(TableTransformer.ANSI_WHITE);
+        }
+        sb.append("(");
+        sb.append(toWrap);
+        sb.append(")");
+        if(color) {
+            sb.append(TableTransformer.ANSI_RESET);
+        }
+        return sb.toString();
+    }
+    public static String toDateString(long time, TimeUnit unit, boolean color) {
+        return wrapQuiet(new java.text.SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new java.util.Date (unit.toMillis(time))), color);
+    }
+
+    public static String toDurationString(long duration, TimeUnit unit, boolean color) {
+        return wrapQuiet(PeriodFormat.getDefault().print(new Duration(unit.toMillis(duration)).toPeriod()), color);
+    }
+
+    public static String toByteString(long bytes, boolean si, boolean color) {
+        int unit = si ? 1000 : 1024;
+        if (bytes < unit) return bytes + " B";
+        int exp = (int) (Math.log(bytes) / Math.log(unit));
+        String pre = (si ? "kMGTPE" : "KMGTPE").charAt(exp-1) + (si ? "" : "i");
+        return wrapQuiet(String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre), color);
+    }
+
+    private static class ValuedByteBuffer {
+        public long value;
+        public ByteBuffer buffer;
+        public ValuedByteBuffer(ByteBuffer buffer, long value) {
+            this.value = value;
+            this.buffer = buffer;
+        }
+        public long getValue() {
+            return value;
+        }
+    }
+    private static Comparator<ValuedByteBuffer> VCOMP = Comparator.comparingLong(ValuedByteBuffer::getValue).reversed();
+
+    public static void printStats(String fname, PrintStream out, boolean color) throws IOException, NoSuchFieldException, IllegalAccessException {
+        String c = color? TableTransformer.ANSI_BLUE : "";
+        String s = color? TableTransformer.ANSI_CYAN : "";
+        String r = color? TableTransformer.ANSI_RESET : "";
+        if (new File(fname).exists())
+        {
+            Descriptor descriptor = Descriptor.fromFilename(fname);
+            CFMetaData cfm = tableFromBestSource(new File(fname));
+            SSTableReader reader = SSTableReader.openNoValidation(descriptor, cfm);
+            ISSTableScanner scanner = reader.getScanner();
+            long bytes = scanner.getLengthInBytes();
+            MinMaxPriorityQueue<ValuedByteBuffer> widestPartitions = MinMaxPriorityQueue
+                    .orderedBy(VCOMP)
+                    .maximumSize(5)
+                    .create();
+            MinMaxPriorityQueue<ValuedByteBuffer> largestPartitions = MinMaxPriorityQueue
+                    .orderedBy(VCOMP)
+                    .maximumSize(5)
+                    .create();
+            MinMaxPriorityQueue<ValuedByteBuffer> mostTombstones = MinMaxPriorityQueue
+                    .orderedBy(VCOMP)
+                    .maximumSize(5)
+                    .create();
+            long partitionCount = 0;
+            long rowCount = 0;
+            long tombstoneCount = 0;
+            long cellCount = 0;
+
+            while(scanner.hasNext()) {
+                UnfilteredRowIterator partition = scanner.next();
+
+                long psize = 0;
+                long pcount = 0;
+                int ptombcount = 0;
+                partitionCount ++;
+                if(!partition.staticRow().isEmpty()) {
+                    rowCount ++;
+                    pcount++;
+                    psize += partition.staticRow().dataSize();
+                }
+                if(!partition.partitionLevelDeletion().isLive()) {
+                    tombstoneCount ++;
+                    ptombcount++;
+                }
+                while(partition.hasNext()) {
+                    Unfiltered unfiltered = partition.next();
+                    switch(unfiltered.kind()) {
+                        case ROW:
+                            rowCount++;
+                            Row row = (Row) unfiltered;
+                            psize += row.dataSize();
+                            pcount++;
+                            Iterator<Cell> cells = row.cells().iterator();
+                            while(cells.hasNext()) {
+                                Cell cell = cells.next();
+                                cellCount++;
+                                if(cell.isTombstone()) {
+                                    tombstoneCount++;
+                                    ptombcount++;
+                                }
+                            }
+                        break;
+                        case RANGE_TOMBSTONE_MARKER:
+                            tombstoneCount++;
+                            ptombcount++;
+                        break;
+                    }
+                }
+                widestPartitions.add(new ValuedByteBuffer(partition.partitionKey().getKey(), pcount));
+                largestPartitions.add(new ValuedByteBuffer(partition.partitionKey().getKey(), psize));
+                mostTombstones.add(new ValuedByteBuffer(partition.partitionKey().getKey(), ptombcount));
+            }
+            out.printf("%sPartitions%s:%s %s%n", c, s, r, partitionCount);
+            out.printf("%sRows%s:%s %s%n", c, s, r, rowCount);
+            out.printf("%sTombstones%s:%s %s%n", c, s, r, tombstoneCount);
+            out.printf("%sCells%s:%s %s%n", c, s, r, cellCount);
+            out.printf("%sWidest Partitions%s:%s%n", c, s, r);
+            asStream(widestPartitions.iterator()).sorted(VCOMP).forEach(p -> {
+                out.printf("%s   [%s%s%s]%s %s%n", s, r, cfm.getKeyValidator().getString(p.buffer), s, r, p.value);
+            });
+            out.printf("%sLargest Partitions%s:%s%n", c, s, r);
+            asStream(largestPartitions.iterator()).sorted(VCOMP).forEach(p -> {
+                out.printf("%s   [%s%s%s]%s %s %s%n", s, r, cfm.getKeyValidator().getString(p.buffer), s, r, p.value, toByteString(p.value, true, color));
+            });
+            out.printf("%sTombstone Leaders%s:%s%n", c, s, r);
+            asStream(mostTombstones.iterator()).sorted(VCOMP).forEach(p -> {
+                if(p.value > 0) {
+                    out.printf("%s   [%s%s%s]%s %s%n", s, r, cfm.getKeyValidator().getString(p.buffer), s, r, p.value);
+                }
+            });
+
+            Map<MetadataType, MetadataComponent> metadata = descriptor.getMetadataSerializer().deserialize(descriptor, EnumSet.allOf(MetadataType.class));
+            ValidationMetadata validation = (ValidationMetadata) metadata.get(MetadataType.VALIDATION);
+            StatsMetadata stats = (StatsMetadata) metadata.get(MetadataType.STATS);
+            CompactionMetadata compaction = (CompactionMetadata) metadata.get(MetadataType.COMPACTION);
+            CompressionMetadata compression = null;
+            File compressionFile = new File(descriptor.filenameFor(Component.COMPRESSION_INFO));
+            if (compressionFile.exists())
+                compression = CompressionMetadata.create(fname);
+            SerializationHeader.Component header = (SerializationHeader.Component) metadata.get(MetadataType.HEADER);
+            List<AbstractType<?>> clusteringTypes = (List<AbstractType<?>>) readPrivate(header, "clusteringTypes");
+            if (validation != null)
+            {
+                out.printf("%sPartitioner%s:%s %s%n", c, s, r, validation.partitioner);
+                out.printf("%sBloom Filter FP chance%s:%s %f%n", c, s, r, validation.bloomFilterFPChance);
+            }
+            if (stats != null)
+            {
+                out.printf("%sSize%s:%s %s %s %n", c, s, r, bytes, toByteString(bytes, true, color));
+                out.printf("%sCompressor%s:%s %s%n", c, s, r, compression != null ? compression.compressor().getClass().getName() : "-");
+                if (compression != null)
+                    out.printf("%s  Compression ratio%s:%s %s%n", c, s, r, stats.compressionRatio);
+
+                out.printf("%sMinimum timestamp%s:%s %s %s%n", c, s, r, stats.minTimestamp, toDateString(stats.minTimestamp, TimeUnit.MICROSECONDS, color));
+                out.printf("%sMaximum timestamp%s:%s %s %s%n", c, s, r, stats.maxTimestamp, toDateString(stats.maxTimestamp, TimeUnit.MICROSECONDS, color));
+
+                out.printf("%sSSTable min local deletion time%s:%s %s %s%n", c, s, r, stats.minLocalDeletionTime, toDateString(stats.minLocalDeletionTime, TimeUnit.SECONDS, color));
+                out.printf("%sSSTable max local deletion time%s:%s %s %s%n", c, s, r, stats.maxLocalDeletionTime, toDateString(stats.maxLocalDeletionTime, TimeUnit.SECONDS, color));
+
+                out.printf("%sTTL min%s:%s %s %s%n", c, s, r, stats.minTTL, toDurationString(stats.minTTL, TimeUnit.SECONDS, color));
+                out.printf("%sTTL max%s:%s %s %s%n", c, s, r, stats.maxTTL, toDurationString(stats.maxTTL, TimeUnit.SECONDS, color));
+                if (header != null && clusteringTypes.size() == stats.minClusteringValues.size())
+                {
+                    List<ByteBuffer> minClusteringValues = stats.minClusteringValues;
+                    List<ByteBuffer> maxClusteringValues = stats.maxClusteringValues;
+                    String[] minValues = new String[clusteringTypes.size()];
+                    String[] maxValues = new String[clusteringTypes.size()];
+                    for (int i = 0; i < clusteringTypes.size(); i++)
+                    {
+                        minValues[i] = clusteringTypes.get(i).getString(minClusteringValues.get(i));
+                        maxValues[i] = clusteringTypes.get(i).getString(maxClusteringValues.get(i));
+                    }
+                    out.printf("%sminClustringValues%s:%s %s%n", c, s, r, Arrays.toString(minValues));
+                    out.printf("%smaxClustringValues%s:%s %s%n", c, s, r, Arrays.toString(maxValues));
+                }
+                out.printf("%sEstimated droppable tombstones%s:%s %s%n", c, s, r, stats.getEstimatedDroppableTombstoneRatio((int) (System.currentTimeMillis() / 1000)));
+                out.printf("%sSSTable Level%s:%s %d%n", c, s, r, stats.sstableLevel);
+                out.printf("%sRepaired at%s:%s %d %s%n", c, s, r, stats.repairedAt, toDateString(stats.repairedAt, TimeUnit.MILLISECONDS, color));
+                out.println("  " + stats.replayPosition);
+                out.printf("%stotalColumnsSet%s:%s %s%n", c, s, r, stats.totalColumnsSet);
+                out.printf("%stotalRows%s:%s %s%n", c, s, r, stats.totalRows);
+                out.printf("%sEstimated tombstone drop times%s:%s%n", c, s, r);
+
+                for (Map.Entry<Double, Long> entry : stats.estimatedTombstoneDropTime.getAsMap().entrySet())
+                {
+                    out.printf("  %-10s %s:%10s%n", entry.getKey().intValue(),
+                            toDateString(entry.getKey().intValue(), TimeUnit.SECONDS, color), entry.getValue());
+                }
+            }
+            if (compaction != null)
+            {
+                out.printf("%sEstimated cardinality%s:%s %s%n", c, s, r, compaction.cardinalityEstimator.cardinality());
+            }
+            if (header != null)
+            {
+                EncodingStats encodingStats = (EncodingStats) readPrivate(header, "stats");
+                AbstractType<?> keyType = (AbstractType<?>) readPrivate(header, "keyType");
+                Map<ByteBuffer, AbstractType<?>> staticColumns = (Map<ByteBuffer, AbstractType<?>>) readPrivate(header, "staticColumns");
+                Map<ByteBuffer, AbstractType<?>> regularColumns = (Map<ByteBuffer, AbstractType<?>>) readPrivate(header, "regularColumns");
+                Map<String, String> statics = staticColumns.entrySet().stream()
+                        .collect(Collectors.toMap(
+                                e -> UTF8Type.instance.getString(e.getKey()),
+                                e -> e.getValue().toString()));
+                Map<String, String> regulars = regularColumns.entrySet().stream()
+                        .collect(Collectors.toMap(
+                                e -> UTF8Type.instance.getString(e.getKey()),
+                                e -> e.getValue().toString()));
+
+                out.printf("%sEncodingStats minTTL%s:%s %s %s%n", c, s, r, encodingStats.minTTL, toDurationString(encodingStats.minTTL, TimeUnit.SECONDS, color));
+                out.printf("%sEncodingStats minLocalDeletionTime%s:%s %s %s%n", c, s, r, encodingStats.minLocalDeletionTime, toDateString(encodingStats.minLocalDeletionTime, TimeUnit.MILLISECONDS, color));
+                out.printf("%sEncodingStats minTimestamp%s:%s %s %s%n", c, s, r, encodingStats.minTimestamp, toDateString(encodingStats.minTimestamp, TimeUnit.MICROSECONDS, color));
+                out.printf("%sKeyType%s:%s %s%n", c, s, r, keyType.toString());
+                out.printf("%sClusteringTypes%s:%s %s%n", c, s, r, clusteringTypes.toString());
+                out.printf("%sStaticColumns%s:%s {%s}%n", c, s, r, FBUtilities.toString(statics));
+                out.printf("%sRegularColumns%s:%s {%s}%n", c, s, r, FBUtilities.toString(regulars));
+            }
+        }
+
     }
 }

--- a/src/main/java/com/csforge/sstable/Cqlsh.java
+++ b/src/main/java/com/csforge/sstable/Cqlsh.java
@@ -309,7 +309,13 @@ public class Cqlsh {
                 }
                 break;
             default:
-                System.err.println(IMPROPER_PAGING_COMMAND);
+                try {
+                    pageSize = Integer.parseInt(mode);
+                    paging = true;
+                    System.out.printf(QUERY_PAGING_ENABLED, pageSize);
+                } catch (NumberFormatException e) {
+                    System.err.println(IMPROPER_PAGING_COMMAND);
+                }
         }
     }
 

--- a/src/main/java/com/csforge/sstable/Cqlsh.java
+++ b/src/main/java/com/csforge/sstable/Cqlsh.java
@@ -1,0 +1,131 @@
+package com.csforge.sstable;
+
+import com.google.common.collect.Lists;
+import jline.console.ConsoleReader;
+import jline.console.history.FileHistory;
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.commons.cli.*;
+
+import java.io.*;
+import java.util.List;
+
+public class Cqlsh {
+
+    private static final Options options = new Options();
+
+    private static final String SCHEMA_OPTION = "s";
+
+    private static final String FILE_OPTION = "f";
+
+    static {
+        Option schemaOption = new Option(SCHEMA_OPTION, true, "Schema file to use.");
+        schemaOption.setRequired(true);
+
+        Option fileOption = new Option(FILE_OPTION, true, "Execute commands from FILE, then exit.");
+
+        options.addOption(schemaOption);
+        options.addOption(fileOption);
+    }
+
+    public static void main(String args[]) {
+        CommandLineParser parser = new PosixParser();
+        CommandLine cmd = null;
+        try {
+            cmd = parser.parse(options, args);
+            if (cmd.getArgs().length == 0) {
+                throw new ParseException("You must supply at least one sstable.");
+            }
+        } catch (ParseException e) {
+            System.err.format("Failure parsing arguments: %s%n%n", e.getMessage());
+            try (PrintWriter errWriter = new PrintWriter(System.err, true)) {
+                HelpFormatter formatter = new HelpFormatter();
+                formatter.printHelp(errWriter, 120, "cqlsh sstable [sstable ...]",
+                        String.format("%nOffline CQL Shell for Apache Cassandra 3.x%nOptions:"),
+                        options, 2, 1, "", true);
+            } finally {
+                System.exit(-1);
+            }
+        }
+
+        List<File> sstables = Lists.newArrayList();
+        for (String sstable : cmd.getArgs()) {
+            File file = new File(sstable);
+            if (!file.exists()) {
+                System.err.println("Non-existant sstable file provided: " + sstable);
+                System.exit(-3);
+            }
+            sstables.add(file);
+        }
+        String schemaPath = cmd.getOptionValue(SCHEMA_OPTION);
+        String cqlFilePath = cmd.getOptionValue(FILE_OPTION);
+        CFMetaData metadata = null;
+
+        try (InputStream schemaStream = new FileInputStream(new File(schemaPath))) {
+            metadata = CassandraUtils.tableFromCQL(schemaStream);
+        } catch (IOException e) {
+            System.err.println("Error reading schema metadata: " + e.getMessage());
+            System.exit(-2);
+        }
+
+        try {
+            ConsoleReader console = new ConsoleReader();
+            console.setPrompt("cqlsh> ");
+            FileHistory history = new FileHistory(new File(System.getProperty("user.home"), ".sstable-tools-cqlsh"));
+            console.setHistory(history);
+            console.setHistoryEnabled(true);
+
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        history.flush();
+                    } catch (IOException e) {
+                        System.err.println("Couldn't flush history on shutdown.  Reason:" + e.getMessage());
+                    }
+                }
+            });
+
+            try {
+                String line;
+                boolean done = false;
+                while (!done && (line = console.readLine()) != null) {
+                    // TODO: Handle semi-colons in quoted identifers.
+                    String cmds[] = line.split(";");
+                    for (String command : cmds) {
+                        command = command.trim();
+                        if (command.equals("exit")) {
+                            done = true;
+                            continue;
+                        } else if (command.length() >= 6) {
+                            String queryType = command.substring(0, 6).toLowerCase();
+                            switch (queryType) {
+                                case "select":
+                                    try {
+                                        Query query = new Query(command, sstables.get(0), metadata);
+                                        TableTransformer.dumpResults(metadata, query.getResults(), System.out);
+                                    } catch (Exception e) {
+                                        System.err.println(e.getMessage());
+                                    }
+                                    continue;
+                                case "update":
+                                case "insert":
+                                case "create":
+                                case "delete":
+                                    System.err.format("Query '%s' is not supported since this tool is read-only.%n", command);
+                                    continue;
+                            }
+                        }
+                        System.err.format("Unknown command: %s%n", command);
+                    }
+                }
+            } finally {
+                history.flush();
+                console.shutdown();
+            }
+        } catch (IOException e) {
+            System.err.println("Error in console session: " + e.getMessage());
+            System.exit(-4);
+        }
+
+    }
+}

--- a/src/main/java/com/csforge/sstable/Cqlsh.java
+++ b/src/main/java/com/csforge/sstable/Cqlsh.java
@@ -1,14 +1,43 @@
 package com.csforge.sstable;
 
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.io.Resources;
 import jline.console.ConsoleReader;
+import jline.console.UserInterruptException;
+import jline.console.completer.FileNameCompleter;
 import jline.console.history.FileHistory;
 import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.CreateTableStatement;
+import org.apache.cassandra.cql3.statements.CreateTypeStatement;
+import org.apache.cassandra.cql3.statements.ParsedStatement;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.commons.cli.*;
 
 import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
 import java.util.List;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
+/**
+ * This is just an early hacking - proof of concept (don't judge)
+ *
+ * - TODO : REWRITE EVERYTHING FROM SCRATCH
+ *
+ * - TODO : UDTs, and UDFs
+ * - TODO : EXPAND ON; like cqlsh for wide rows/tiny consoles
+ * - TODO : File completer on sstable use/select
+ */
 public class Cqlsh {
 
     private static final Options options = new Options();
@@ -16,15 +45,264 @@ public class Cqlsh {
     private static final String SCHEMA_OPTION = "s";
 
     private static final String FILE_OPTION = "f";
+    private static final String MISSING_SSTABLES = TableTransformer.ANSI_RED +
+            "No sstables set. Set the sstables using the 'USE pathToSSTable' command." +
+            TableTransformer.ANSI_RESET;
 
     static {
         Option schemaOption = new Option(SCHEMA_OPTION, true, "Schema file to use.");
-        schemaOption.setRequired(true);
-
+        schemaOption.setRequired(false);
         Option fileOption = new Option(FILE_OPTION, true, "Execute commands from FILE, then exit.");
-
         options.addOption(schemaOption);
         options.addOption(fileOption);
+    }
+
+    public List<File> sstables = Lists.newArrayList();
+    public FileHistory history = null;
+    private final String prompt = "\u001B[1;33mcqlsh\u001B[33m> \u001B[0m";
+    public CFMetaData metadata = null;
+    private boolean done = false;
+    ConsoleReader console;
+
+    String innerBuffer;
+    boolean inner = false;
+
+    public Cqlsh() {
+        try {
+            history = new FileHistory(new File(System.getProperty("user.home"), ".sstable-tools-cqlsh"));
+            console = new ConsoleReader();
+            console.setPrompt(prompt);
+            console.setHistory(history);
+            console.setHistoryEnabled(true);
+            console.addCompleter(new FileNameCompleter());
+            console.setHandleUserInterrupt(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void startShell() throws Exception {
+        try {
+            String line = null;
+            while (!done && (line = console.readLine()) != null) {
+                evalLine(line);
+            }
+            if (line == null) {
+                done = true;
+            }
+        } catch (IOException e) {
+            System.err.println("Error in console session: " + e.getMessage());
+            System.exit(-4);
+        }
+    }
+
+    public void doUse(String command) throws Exception {
+        String rest = command.substring(4); // "USE "
+        Pattern p = Pattern.compile("((\"[^\"]+\")|[^\" ]+)");
+        Matcher m = p.matcher(rest);
+        this.sstables = Lists.newArrayList();
+
+        while (m.find()) {
+            String arg = m.group().replace("\"", "");
+            File sstable = new File(arg);
+            if (sstable.exists() && sstable.isFile()) {
+                this.sstables.add(sstable);
+            } else {
+                try {
+                    if (sstable.exists()) {
+                        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:**/*-Data.db");
+                        Files.walkFileTree(Paths.get(arg), Sets.newHashSet(), 1, new SimpleFileVisitor<Path>() {
+                            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
+                                if (matcher.matches(path)) {
+                                    sstables.add(path.toFile());
+                                }
+                                return FileVisitResult.CONTINUE;
+                            }
+
+                            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                                return FileVisitResult.CONTINUE;
+                            }
+                        });
+                    } else {
+                        System.out.println("Cannot find " + sstable.getAbsolutePath());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        for (File f : sstables) {
+            System.out.println("Using: " + f.getAbsolutePath());
+        }
+        if (!sstables.isEmpty()) {
+            metadata = CassandraUtils.tableFromBestSource(sstables.get(0));
+        }
+    }
+
+    public void doDump(String command) throws Exception {
+        if(sstables.isEmpty()) {
+            System.out.println(MISSING_SSTABLES);
+            return;
+        }
+        Query query;
+        if (command.length() > 5) {
+            query = getQuery("select * from sstables " + command.substring(5));
+        } else {
+            query = getQuery("select * from sstables");
+        }
+        Stream<UnfilteredRowIterator> partitions = CassandraUtils.asStream(query.getScanner());
+
+        partitions.forEach(partition -> {
+            if(!partition.partitionLevelDeletion().isLive()) {
+                System.out.println("[" + metadata.getKeyValidator().getString(partition.partitionKey().getKey()) + "] " +
+                        partition.partitionLevelDeletion());
+            }
+            if (!partition.staticRow().isEmpty()) {
+                System.out.println(
+                    "[" + metadata.getKeyValidator().getString(partition.partitionKey().getKey()) + "] " +
+                            partition.staticRow().toString(metadata, true));
+            }
+            partition.forEachRemaining(row -> {
+                System.out.println(
+                        "[" + metadata.getKeyValidator().getString(partition.partitionKey().getKey()) + "] " +
+                                row.toString(metadata, true));
+            });
+        });
+        System.out.println();
+    }
+
+    public void doCreate(String command) throws Exception {
+        innerBuffer = command;
+        inner = true;
+        history.removeLast();
+        console.setHistoryEnabled(false);
+        console.setPrompt("...    ");
+        try {
+            while (inner) {
+                try {
+                    ParsedStatement statement = QueryProcessor.parseStatement(innerBuffer);
+                    inner = false;
+                    history.add(innerBuffer);
+                    if (statement instanceof CreateTableStatement.RawStatement) {
+                        CassandraUtils.cqlOverride = innerBuffer;
+                    } else if (statement instanceof CreateTypeStatement) {
+                        try {
+                            // TODO work around type mess
+                            System.out.println(CassandraUtils.callPrivate(statement, "createType"));
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    //CreateTableStatement$RawStatement
+                } catch (SyntaxException e) {
+                    if (!innerBuffer.trim().endsWith(";")) {
+                        String line = console.readLine();
+                        if (!inner) {
+                            evalLine(line);
+                        } else {
+                            innerBuffer += " " + line;
+                        }
+                    } else {
+                        inner = false;
+                        System.out.println(TableTransformer.ANSI_RED + e.getMessage() + TableTransformer.ANSI_RESET);
+                    }
+                }
+            }
+        } finally {
+            console.setHistoryEnabled(true);
+            console.setPrompt(prompt);
+            innerBuffer = "";
+            inner = false;
+        }
+    }
+
+    public Query getQuery(String command) throws Exception {
+        SelectStatement.RawStatement statement = (SelectStatement.RawStatement) QueryProcessor.parseStatement(command);
+        Query query;
+        if (statement.columnFamily().matches("sstables?")) {
+            if(sstables.isEmpty()) {
+                return null;
+            }
+            metadata = CassandraUtils.tableFromBestSource(sstables.get(0));
+            return new Query(command, sstables, metadata);
+        } else {
+            File path = new File(statement.columnFamily());
+            if (!path.exists()) {
+                throw new FileNotFoundException(path.getAbsolutePath());
+            }
+            metadata = CassandraUtils.tableFromBestSource(path);
+            return new Query(command, Collections.singleton(path), metadata);
+        }
+    }
+
+    public void evalLine(String line) throws Exception {
+        // TODO: Handle semi-colons in quoted identifers.
+        String cmds[] = line.split(";");
+        for (String command : cmds) {
+            command = command.trim();
+            if (command.equals("exit") || command.equals("quit")) {
+                done = true;
+                continue;
+            } else if (command.toLowerCase().trim().startsWith("describe schema")) {
+                if(CassandraUtils.cqlOverride != null) {
+                    System.out.println(CassandraUtils.cqlOverride);
+                } else if (metadata != null) {
+                    System.out.println(metadata);
+                } else {
+                    System.err.format("%sNo current metadata set, use a CREATE TABLE statement to set%s%n",
+                            TableTransformer.ANSI_RED, TableTransformer.ANSI_RESET);
+                }
+                continue;
+            } else if (command.toLowerCase().trim().startsWith("describe sstable")) {
+                System.out.println();
+                for(File f : sstables) {
+                    System.out.println("\u001B[1;34m" + f.getAbsolutePath());
+                    System.out.println(TableTransformer.ANSI_CYAN +
+                            Strings.repeat("=", f.getAbsolutePath().length()) +
+                            TableTransformer.ANSI_RESET);
+                    CassandraUtils.printStats(f.getAbsolutePath(), System.out, true);
+                    System.out.println();
+                }
+                continue;
+            } else if (command.toLowerCase().startsWith("use ")) {
+                doUse(command);
+                continue;
+            } else if (command.toLowerCase().startsWith("dump")) {
+                doDump(command);
+                continue;
+            } else if (command.toLowerCase().equals("help")) {
+                try {
+                    System.out.println(Resources.toString(Resources.getResource("cqlsh-help"), Charsets.UTF_8));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    System.exit(-5);
+                }
+                continue;
+            } else if (command.length() >= 6) {
+                String queryType = command.substring(0, 6).toLowerCase();
+                switch (queryType) {
+                    case "select":
+                        Query q = getQuery(command);
+                        if(q == null) {
+                            System.out.println(MISSING_SSTABLES);
+                        } else {
+                            TableTransformer.dumpResults(metadata, getQuery(command).getResults(), System.out);
+                        }
+                        continue;
+                    case "create":
+                        doCreate(command);
+                        continue;
+                    case "update":
+                    case "insert":
+                    case "delete":
+                        System.err.format("%sQuery '%s' is not supported since this tool is read-only.%s%n",
+                                TableTransformer.ANSI_RED, command, TableTransformer.ANSI_RESET);
+                        continue;
+                }
+            }
+            System.err.format("%sUnknown command: %s%s%n", TableTransformer.ANSI_RED, command,
+                    TableTransformer.ANSI_RESET);
+        }
     }
 
     public static void main(String args[]) {
@@ -32,11 +310,9 @@ public class Cqlsh {
         CommandLine cmd = null;
         try {
             cmd = parser.parse(options, args);
-            if (cmd.getArgs().length == 0) {
-                throw new ParseException("You must supply at least one sstable.");
-            }
         } catch (ParseException e) {
-            System.err.format("Failure parsing arguments: %s%n%n", e.getMessage());
+            System.err.format("%sFailure parsing arguments: %s%s%n%n", TableTransformer.ANSI_RED, e.getMessage(),
+                    TableTransformer.ANSI_RESET);
             try (PrintWriter errWriter = new PrintWriter(System.err, true)) {
                 HelpFormatter formatter = new HelpFormatter();
                 formatter.printHelp(errWriter, 120, "cqlsh sstable [sstable ...]",
@@ -45,6 +321,19 @@ public class Cqlsh {
             } finally {
                 System.exit(-1);
             }
+        }
+
+        final Cqlsh sh = new Cqlsh();
+
+        String schemaPath = cmd.getOptionValue(SCHEMA_OPTION);
+        if (schemaPath != null) {
+            try (InputStream schemaStream = new FileInputStream(new File(schemaPath))) {
+                sh.metadata = CassandraUtils.tableFromCQL(schemaStream);
+            } catch (IOException e) {
+                System.err.println("Error reading schema metadata: " + e.getMessage());
+                System.exit(-2);
+            }
+            System.setProperty("sstabletools.schema", schemaPath);
         }
 
         List<File> sstables = Lists.newArrayList();
@@ -56,75 +345,48 @@ public class Cqlsh {
             }
             sstables.add(file);
         }
-        String schemaPath = cmd.getOptionValue(SCHEMA_OPTION);
-        String cqlFilePath = cmd.getOptionValue(FILE_OPTION);
-        CFMetaData metadata = null;
 
-        try (InputStream schemaStream = new FileInputStream(new File(schemaPath))) {
-            metadata = CassandraUtils.tableFromCQL(schemaStream);
-        } catch (IOException e) {
-            System.err.println("Error reading schema metadata: " + e.getMessage());
-            System.exit(-2);
-        }
-
-        try {
-            ConsoleReader console = new ConsoleReader();
-            console.setPrompt("cqlsh> ");
-            FileHistory history = new FileHistory(new File(System.getProperty("user.home"), ".sstable-tools-cqlsh"));
-            console.setHistory(history);
-            console.setHistoryEnabled(true);
-
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    try {
-                        history.flush();
-                    } catch (IOException e) {
-                        System.err.println("Couldn't flush history on shutdown.  Reason:" + e.getMessage());
-                    }
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                try {
+                    sh.history.flush();
+                } catch (IOException e) {
+                    System.err.println("Couldn't flush history on shutdown.  Reason:" + e.getMessage());
                 }
-            });
-
-            try {
-                String line;
-                boolean done = false;
-                while (!done && (line = console.readLine()) != null) {
-                    // TODO: Handle semi-colons in quoted identifers.
-                    String cmds[] = line.split(";");
-                    for (String command : cmds) {
-                        command = command.trim();
-                        if (command.equals("exit")) {
-                            done = true;
-                            continue;
-                        } else if (command.length() >= 6) {
-                            String queryType = command.substring(0, 6).toLowerCase();
-                            switch (queryType) {
-                                case "select":
-                                    try {
-                                        Query query = new Query(command, sstables.get(0), metadata);
-                                        TableTransformer.dumpResults(metadata, query.getResults(), System.out);
-                                    } catch (Exception e) {
-                                        System.err.println(e.getMessage());
-                                    }
-                                    continue;
-                                case "update":
-                                case "insert":
-                                case "create":
-                                case "delete":
-                                    System.err.format("Query '%s' is not supported since this tool is read-only.%n", command);
-                                    continue;
-                            }
-                        }
-                        System.err.format("Unknown command: %s%n", command);
-                    }
-                }
-            } finally {
-                history.flush();
-                console.shutdown();
             }
-        } catch (IOException e) {
-            System.err.println("Error in console session: " + e.getMessage());
-            System.exit(-4);
+        });
+
+        String cqlFilePath = cmd.getOptionValue(FILE_OPTION);
+        if (cqlFilePath != null) {
+            try (Scanner s = new Scanner(new FileInputStream(cqlFilePath))) {
+                while (s.hasNextLine()) {
+                    try {
+                        sh.evalLine(s.nextLine());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        break;
+                    }
+                }
+            } catch (FileNotFoundException ex) {
+                System.err.println("Cannot find " + cqlFilePath);
+                System.exit(-4);
+            }
+        } else {
+
+            while (!sh.done) {
+                try {
+                    sh.startShell();
+                } catch (UserInterruptException e) {
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+            try {
+                sh.history.flush();
+            } catch (IOException e) {
+            }
+            sh.console.shutdown();
         }
 
     }

--- a/src/main/java/com/csforge/sstable/Driver.java
+++ b/src/main/java/com/csforge/sstable/Driver.java
@@ -1,5 +1,8 @@
 package com.csforge.sstable;
 
+import com.google.common.base.Strings;
+
+import java.io.IOException;
 import java.util.Arrays;
 
 public class Driver {
@@ -21,6 +24,18 @@ public class Driver {
                 Cqlsh.main(Arrays.copyOfRange(args, 1, args.length));
                 break;
 
+            case "describe":
+                String path = args[1];
+                try {
+                    System.out.println("\u001B[1;34m" + path);
+                    System.out.println(TableTransformer.ANSI_CYAN + Strings.repeat("=", path.length()));
+                    System.out.print(TableTransformer.ANSI_RESET);
+                    CassandraUtils.printStats(path, System.out, true);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                break;
+
             default:
                 System.err.println("Unknown command: " + args[0]);
                 printCommands();
@@ -30,6 +45,6 @@ public class Driver {
     }
 
     private static void printCommands() {
-        System.err.println("Available commands: cqlsh, toJson, select");
+        System.err.println("Available commands: cqlsh, toJson, select, describe");
     }
 }

--- a/src/main/java/com/csforge/sstable/Driver.java
+++ b/src/main/java/com/csforge/sstable/Driver.java
@@ -17,6 +17,10 @@ public class Driver {
                 Query.main(Arrays.copyOfRange(args, 0, args.length));
                 break;
 
+            case "cqlsh":
+                Cqlsh.main(Arrays.copyOfRange(args, 1, args.length));
+                break;
+
             default:
                 System.err.println("Unknown command: " + args[0]);
                 printCommands();
@@ -26,6 +30,6 @@ public class Driver {
     }
 
     private static void printCommands() {
-        System.err.println("Available commands: toJson, select");
+        System.err.println("Available commands: cqlsh, toJson, select");
     }
 }

--- a/src/main/java/com/csforge/sstable/Driver.java
+++ b/src/main/java/com/csforge/sstable/Driver.java
@@ -30,7 +30,7 @@ public class Driver {
                     System.out.println("\u001B[1;34m" + path);
                     System.out.println(TableTransformer.ANSI_CYAN + Strings.repeat("=", path.length()));
                     System.out.print(TableTransformer.ANSI_RESET);
-                    CassandraUtils.printStats(path, System.out, true);
+                    CassandraUtils.printStats(path, System.out);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/com/csforge/sstable/PagingData.java
+++ b/src/main/java/com/csforge/sstable/PagingData.java
@@ -1,0 +1,39 @@
+package com.csforge.sstable;
+
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DecoratedKey;
+
+class PagingData {
+
+    final DecoratedKey partitionKey;
+
+    final Clustering clustering;
+
+    final int rowCount;
+
+    public PagingData() {
+        this(null, null, 0);
+    }
+
+    public PagingData(DecoratedKey partitionKey, Clustering clustering, int rowCount) {
+        this.partitionKey = partitionKey;
+        this.clustering = clustering;
+        this.rowCount = rowCount;
+    }
+
+    boolean hasMorePages() {
+        return partitionKey != null && clustering != null;
+    }
+
+    public DecoratedKey getPartitionKey() {
+        return partitionKey;
+    }
+
+    public Clustering getClustering() {
+        return clustering;
+    }
+
+    public Integer getRowCount() {
+        return rowCount;
+    }
+}

--- a/src/main/java/com/csforge/sstable/Query.java
+++ b/src/main/java/com/csforge/sstable/Query.java
@@ -1,22 +1,19 @@
 package com.csforge.sstable;
 
 import com.csforge.sstable.reader.Partition;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.ColumnDefinition;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.cql3.selection.Selection;
 import org.apache.cassandra.cql3.statements.Bound;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.cql3.statements.StatementType;
-import org.apache.cassandra.db.Clustering;
-import org.apache.cassandra.db.DataRange;
-import org.apache.cassandra.db.Slice;
-import org.apache.cassandra.db.Slices;
+import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.*;
 import org.apache.cassandra.db.marshal.CollectionType;
 import org.apache.cassandra.db.partitions.PartitionIterator;
@@ -26,6 +23,8 @@ import org.apache.cassandra.db.rows.ComplexColumnData;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -37,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -154,36 +154,87 @@ public class Query {
     }
 
     public UnfilteredPartitionIterator getScanner() throws IOException {
-        DataRange range = new DataRange(restrictions.getPartitionKeyBounds(OPTIONS), makeClusteringIndexFilter());
+        return getScanner(Integer.MAX_VALUE, new PagingData());
+    }
+
+    public UnfilteredPartitionIterator getScanner(int pageSize, PagingData pagingData) throws IOException {
+        Preconditions.checkNotNull(pagingData);
+        AbstractBounds<PartitionPosition> bounds = restrictions.getPartitionKeyBounds(OPTIONS);
+        DataRange range = new DataRange(bounds, makeClusteringIndexFilter());
+        final DataRange pageRange;
+        if (pagingData.hasMorePages()) {
+            pageRange = range.forPaging(new Bounds<>(pagingData.getPartitionKey(), bounds.right),
+                    cfm.comparator, pagingData.getClustering(), false);
+        } else {
+            pageRange = range;
+        }
         List<SSTableReader> readers = Lists.newArrayList();
-        for(File f : path) {
+        for (File f : path) {
             Descriptor desc = Descriptor.fromFilename(f.getAbsolutePath());
             readers.add(SSTableReader.openNoValidation(desc, cfm));
         }
         int now = FBUtilities.nowInSeconds();
-        List<UnfilteredPartitionIterator> all = readers.stream().map(r -> r.getScanner(queriedColumns, range, false)).collect(Collectors.toList());
+        List<UnfilteredPartitionIterator> all = readers.stream().map(r -> r.getScanner(queriedColumns, pageRange, false)).collect(Collectors.toList());
         UnfilteredPartitionIterator ret = UnfilteredPartitionIterators.mergeLazily(all, now);
         ret = restrictions.getRowFilter(null, OPTIONS).filter(ret, now);
         if (statement.limit != null && !selection.isAggregate()) {
             int limit = Integer.parseInt(statement.limit.getText());
-            ret = DataLimits.cqlLimits(limit).filter(ret, now);
+            DataLimits limits = DataLimits.cqlLimits(limit);
+            if (pageSize != Integer.MAX_VALUE) {
+                if (pagingData.hasMorePages()) {
+                    limits = limits.forPaging(pageSize, pagingData.getPartitionKey().getKey(), limit - pagingData.getRowCount());
+                } else {
+                    limits = limits.forPaging(pageSize);
+                }
+            }
+            ret = limits.filter(ret, now);
         }
         return ret;
     }
 
-    public ResultSet getResults() throws IOException {
-        int now = FBUtilities.nowInSeconds();
-        Selection.ResultSetBuilder result = selection.resultSetBuilder(statement.parameters.isJson);
-        PartitionIterator partitions = UnfilteredPartitionIterators.filter(getScanner(), now);
-        while (partitions.hasNext()) {
-            try (RowIterator partition = partitions.next()) {
-                processPartition(partition, OPTIONS, result, now);
-            }
-        }
-        return result.build(OPTIONS.getProtocolVersion());
+    public ResultSetData getResults() throws IOException {
+        return getResults(Integer.MAX_VALUE);
     }
 
-    void processPartition(RowIterator partition, QueryOptions options, Selection.ResultSetBuilder result, int nowInSec)
+    public ResultSetData getResults(int pageSize) throws IOException {
+        return getResults(pageSize, new PagingData());
+    }
+
+    public ResultSetData getResults(int pageSize, PagingData pagingData) throws IOException {
+        Preconditions.checkNotNull(pagingData);
+        int now = FBUtilities.nowInSeconds();
+        Selection.ResultSetBuilder result = selection.resultSetBuilder(statement.parameters.isJson);
+        PartitionIterator partitions = UnfilteredPartitionIterators.filter(getScanner(pageSize, pagingData), now);
+        AtomicInteger rowsPaged = new AtomicInteger(0);
+        Clustering newClustering = null;
+        DecoratedKey newPartitionKey = null;
+
+        int limit = statement.limit != null && !selection.isAggregate() ? Integer.parseInt(statement.limit.getText()) : Integer.MAX_VALUE;
+
+        int rowsThusFar = pagingData.getRowCount() + rowsPaged.get();
+        while (rowsThusFar < limit && partitions.hasNext()) {
+            try (RowIterator partition = partitions.next()) {
+                newPartitionKey = partition.partitionKey();
+                // Remaining is the min of how many the requested page size - how many pages
+                // - or - the limit minus rows read overall.
+                newClustering = processPartition(partition, OPTIONS, result, now, Math.min(pageSize - rowsPaged.get(), limit - rowsThusFar), rowsPaged);
+                rowsThusFar = pagingData.getRowCount() + rowsPaged.get();
+                if (newClustering != null) {
+                    break;
+                }
+            }
+        }
+
+        // Stop paging when we hit limit.
+        if (rowsThusFar >= limit) {
+            newClustering = null;
+        }
+
+        PagingData newPagingData = new PagingData(newPartitionKey, newClustering, rowsThusFar);
+        return new ResultSetData(result.build(OPTIONS.getProtocolVersion()), newPagingData);
+    }
+
+    Clustering processPartition(RowIterator partition, QueryOptions options, Selection.ResultSetBuilder result, int nowInSec, int remaining, AtomicInteger rowsPaged)
             throws InvalidRequestException {
         int protocolVersion = options.getProtocolVersion();
 
@@ -206,10 +257,10 @@ public class Query {
                         result.add((ByteBuffer) null);
                 }
             }
-            return;
+            return null;
         }
 
-        while (partition.hasNext()) {
+        while (remaining-- > 0 && partition.hasNext()) {
             Row row = partition.next();
             result.newRow(protocolVersion);
             // Respect selection order
@@ -229,7 +280,12 @@ public class Query {
                         break;
                 }
             }
+            rowsPaged.incrementAndGet();
+            if (remaining <= 0) {
+                return row.clustering();
+            }
         }
+        return null;
     }
 
     private static void addValue(Selection.ResultSetBuilder result, ColumnDefinition def, Row row, int nowInSec, int protocolVersion) {
@@ -262,7 +318,7 @@ public class Query {
                 Stream<UnfilteredRowIterator> stream = StreamSupport.stream(spliterator, false);
                 JsonTransformer.toJson(stream.map(Partition::new), q.cfm, false, System.out);
             } else {
-                TableTransformer.dumpResults(metadata, q.getResults(), System.out);
+                TableTransformer.dumpResults(metadata, q.getResults().getResultSet(), System.out);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/csforge/sstable/ResultSetData.java
+++ b/src/main/java/com/csforge/sstable/ResultSetData.java
@@ -1,0 +1,23 @@
+package com.csforge.sstable;
+
+import org.apache.cassandra.cql3.ResultSet;
+
+public class ResultSetData {
+
+    private final ResultSet resultSet;
+
+    private final PagingData pagingData;
+
+    public ResultSetData(ResultSet resultSet, PagingData pagingData) {
+        this.resultSet = resultSet;
+        this.pagingData = pagingData;
+    }
+
+    public ResultSet getResultSet() {
+        return resultSet;
+    }
+
+    public PagingData getPagingData() {
+        return pagingData;
+    }
+}

--- a/src/main/java/com/csforge/sstable/TableTransformer.java
+++ b/src/main/java/com/csforge/sstable/TableTransformer.java
@@ -48,7 +48,7 @@ public class TableTransformer {
     }
 
     public static void dumpResults(CFMetaData cfm, ResultSet results, PrintStream out) throws Exception {
-
+        if(results.rows.isEmpty()) return; // empty
         // find spacing
         int[] padding = new int[results.rows.get(0).size()];
         for (int i = 0; i < results.rows.get(0).size(); i++) {

--- a/src/main/java/com/csforge/sstable/TableTransformer.java
+++ b/src/main/java/com/csforge/sstable/TableTransformer.java
@@ -4,15 +4,11 @@ import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.ColumnDefinition;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.ResultSet;
-import org.apache.cassandra.db.marshal.CollectionType;
-import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.PrintStream;
-import java.io.PrintWriter;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -89,6 +85,9 @@ public class TableTransformer {
 
         // data
         for (int r = 0; r < results.rows.size(); r++) {
+            if (r > 0) {
+                out.print(" ");
+            }
             List<ByteBuffer> row = results.rows.get(r);
             for (int i = 0; i < row.size(); i++) {
                 out.print(ANSI_WHITE + "│" + ANSI_RESET);
@@ -102,7 +101,6 @@ public class TableTransformer {
                 printLine('├', '─', '┤', '┼', padding, out);
             }
             out.println(ANSI_RESET);
-            out.print(" ");
         }
         out.flush();
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,7 @@
+{
+  "pagingEnabled": true,
+  "pagingSize": 100,
+  "preferencesEnabled": true,
+  "schema": "",
+  "sstables": []
+}

--- a/src/main/resources/cqlsh-help
+++ b/src/main/resources/cqlsh-help
@@ -6,6 +6,8 @@ CREATE TABLE ...  - A CREATE TABLE cql statement to use as metadata when reading
 DESCRIBE SCHEMA   - Show currently used schema (or serialized cfmetadata if generated)
 DESCRIBE SSTABLES - Provide details and statistics on current sstable(s)
 PAGING [(ON|OFF)] - Enables, disables, or shows current status of query paging.
+PAGING <SIZE>     - Enables paging and sets paging size.
+SCHEMA <FILE>     - Imports a cql file as the active table schema.
 USE               - update the sstable[s] used by default with select, dump, describe commands
     USE /var/lib/cassandra/data/system/peers/ma-1-big-Data.db
     or with multiple sstables separated with spaces. This can also be a directory which will add all sstables in it.

--- a/src/main/resources/cqlsh-help
+++ b/src/main/resources/cqlsh-help
@@ -1,0 +1,22 @@
+Commands:
+
+HELP              - prints this message
+EXIT              - leaves the shell
+CREATE TABLE ...  - A CREATE TABLE cql statement to use as metadata when reading sstables (HIGHLY RECOMMENDED!)
+DESCRIBE SCHEMA   - Show currently used schema (or serialized cfmetadata if generated)
+DESCRIBE SSTABLES - Provide details and statistics on current sstable(s)
+USE               - update the sstable[s] used by default with select, dump, describe commands
+    USE /var/lib/cassandra/data/system/peers/ma-1-big-Data.db
+    or with multiple sstables separated with spaces. This can also be a directory which will add all sstables in it.
+    USE ma-1-big-Data.db ma-2-big-Data.db "/home/path with space/db/data/sstables"
+
+SELECT            - run a cql query against the current sstable (unless other specified)
+    SELECT * FROM sstables WHERE key > 1 LIMIT 10
+    the keyword sstables will use the current sstable set with the USE command or set when running cqlsh. You can also
+    specify an sstable here
+    SELECT avg(someColumn) FROM /var/lib/cassandra/data/system/peers/ma-1-big-Data.db WHERE key > 1
+
+DUMP              - dump the raw unfiltered partitions/rows. Useful for debuging TTLed/tombstoned data.
+    DUMP;
+    Can also specify a where clause for filtering the results.
+    DUMP WHERE partitionKey = 'OpsCenter';

--- a/src/main/resources/cqlsh-help
+++ b/src/main/resources/cqlsh-help
@@ -5,6 +5,7 @@ EXIT              - leaves the shell
 CREATE TABLE ...  - A CREATE TABLE cql statement to use as metadata when reading sstables (HIGHLY RECOMMENDED!)
 DESCRIBE SCHEMA   - Show currently used schema (or serialized cfmetadata if generated)
 DESCRIBE SSTABLES - Provide details and statistics on current sstable(s)
+PAGING [(ON|OFF)] - Enables, disables, or shows current status of query paging.
 USE               - update the sstable[s] used by default with select, dump, describe commands
     USE /var/lib/cassandra/data/system/peers/ma-1-big-Data.db
     or with multiple sstables separated with spaces. This can also be a directory which will add all sstables in it.

--- a/src/main/resources/cqlsh-help
+++ b/src/main/resources/cqlsh-help
@@ -1,25 +1,26 @@
 Commands:
 
-HELP              - prints this message
-EXIT              - leaves the shell
-CREATE TABLE ...  - A CREATE TABLE cql statement to use as metadata when reading sstables (HIGHLY RECOMMENDED!)
-DESCRIBE SCHEMA   - Show currently used schema (or serialized cfmetadata if generated)
-DESCRIBE SSTABLES - Provide details and statistics on current sstable(s)
-PAGING [(ON|OFF)] - Enables, disables, or shows current status of query paging.
-PAGING <SIZE>     - Enables paging and sets paging size.
-SCHEMA <FILE>     - Imports a cql file as the active table schema.
-USE               - update the sstable[s] used by default with select, dump, describe commands
+HELP               - prints this message
+EXIT               - leaves the shell
+CREATE TABLE ...   - A CREATE TABLE cql statement to use as metadata when reading sstables (HIGHLY RECOMMENDED!)
+DESCRIBE SCHEMA    - Show currently used schema (or serialized cfmetadata if generated)
+DESCRIBE SSTABLES  - Provide details and statistics on current sstable(s)
+PAGING [(ON|OFF)]  - Enables, disables, or shows current status of query paging.
+PAGING <SIZE>      - Enables paging and sets paging size.
+PERSIST [(ON|OFF)] - Enables, disables, or shows current status of persistence of settings state.
+SCHEMA [<FILE>]    - Imports a cql file as the active table schema or shows active user-defined schema.
+USE                - update the sstable[s] used by default with select, dump, describe commands
     USE /var/lib/cassandra/data/system/peers/ma-1-big-Data.db
     or with multiple sstables separated with spaces. This can also be a directory which will add all sstables in it.
     USE ma-1-big-Data.db ma-2-big-Data.db "/home/path with space/db/data/sstables"
 
-SELECT            - run a cql query against the current sstable (unless other specified)
+SELECT             - run a cql query against the current sstable (unless other specified)
     SELECT * FROM sstables WHERE key > 1 LIMIT 10
     the keyword sstables will use the current sstable set with the USE command or set when running cqlsh. You can also
     specify an sstable here
     SELECT avg(someColumn) FROM /var/lib/cassandra/data/system/peers/ma-1-big-Data.db WHERE key > 1
 
-DUMP              - dump the raw unfiltered partitions/rows. Useful for debuging TTLed/tombstoned data.
+DUMP               - dump the raw unfiltered partitions/rows. Useful for debuging TTLed/tombstoned data.
     DUMP;
     Can also specify a where clause for filtering the results.
     DUMP WHERE partitionKey = 'OpsCenter';

--- a/src/main/resources/jline.configuration
+++ b/src/main/resources/jline.configuration
@@ -1,0 +1,1 @@
+jline.sigcont=true

--- a/src/test/java/com/csforge/sstable/CqlshTests.java
+++ b/src/test/java/com/csforge/sstable/CqlshTests.java
@@ -1,0 +1,33 @@
+package com.csforge.sstable;
+
+
+import junit.framework.Assert;
+import org.apache.cassandra.config.CFMetaData;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+
+public class CqlshTests {
+
+    @Test
+    public void testUse() throws Exception {
+        Cqlsh sh = new Cqlsh();
+        File path = Utils.getDB(3);
+        CFMetaData cfdata = CassandraUtils.tableFromCQL(new ByteArrayInputStream(Utils.CQL3.getBytes()));
+        sh.metadata = cfdata;
+        sh.doUse("USE " + path.getAbsolutePath() + " \"ban ana\"");
+        Assert.assertEquals(path.getAbsoluteFile(), sh.sstables.get(0));
+        Assert.assertEquals(1, sh.sstables.size());
+    }
+
+    @Test
+    public void testUseDirectory() throws Exception {
+        Cqlsh sh = new Cqlsh();
+        File path = Utils.getDB(3);
+        CFMetaData cfdata = CassandraUtils.tableFromCQL(new ByteArrayInputStream(Utils.CQL3.getBytes()));
+        sh.metadata = cfdata;
+        sh.doUse("USE " + path.getParentFile().getAbsolutePath());
+        Assert.assertTrue(sh.sstables.contains(path.getAbsoluteFile()));
+    }
+}

--- a/src/test/java/com/csforge/sstable/CqlshTests.java
+++ b/src/test/java/com/csforge/sstable/CqlshTests.java
@@ -17,7 +17,7 @@ public class CqlshTests {
         CFMetaData cfdata = CassandraUtils.tableFromCQL(new ByteArrayInputStream(Utils.CQL3.getBytes()));
         sh.metadata = cfdata;
         sh.doUse("USE " + path.getAbsolutePath() + " \"ban ana\"");
-        Assert.assertEquals(path.getAbsoluteFile(), sh.sstables.get(0));
+        Assert.assertEquals(path.getAbsoluteFile(), sh.sstables.iterator().next());
         Assert.assertEquals(1, sh.sstables.size());
     }
 

--- a/src/test/java/com/csforge/sstable/SelectTests.java
+++ b/src/test/java/com/csforge/sstable/SelectTests.java
@@ -71,7 +71,7 @@ public class SelectTests {
         String query = String.format("SELECT count(*) FROM \"%s\"", path);
         CFMetaData cfdata = CassandraUtils.tableFromCQL(new ByteArrayInputStream(Utils.CQL3.getBytes()));
         Query q = new Query(query, Collections.singleton(path), cfdata);
-        ResultSet result = q.getResults();
+        ResultSet result = q.getResults().getResultSet();
         Assert.assertEquals(1, result.rows.size());
         Assert.assertEquals("count", result.metadata.names.get(0).name.toString());
     }
@@ -82,7 +82,7 @@ public class SelectTests {
         String query = String.format("SELECT * FROM \"%s\"", path);
         CFMetaData cfdata = CassandraUtils.tableFromCQL(new ByteArrayInputStream(Utils.CQL4.getBytes()));
         Query q = new Query(query, Collections.singleton(path), cfdata);
-        ResultSet result = q.getResults();
+        ResultSet result = q.getResults().getResultSet();
         Assert.assertEquals(1, result.rows.size());
         TableTransformer.dumpResults(cfdata, result, System.out);
 

--- a/src/test/java/com/csforge/sstable/Utils.java
+++ b/src/test/java/com/csforge/sstable/Utils.java
@@ -9,6 +9,27 @@ import java.io.InputStream;
 import java.net.URLClassLoader;
 
 public class Utils {
+    public static String CQL1 =
+            "    CREATE TABLE composites (\n" +
+                    "        key1 varchar,\n" +
+                    "        key2 varchar,\n" +
+                    "        ckey1 varchar,\n" +
+                    "        ckey2 varchar,\n" +
+                    "        value bigint,\n" +
+                    "        PRIMARY KEY((key1, key2), ckey1, ckey2)\n" +
+                    "    );";
+
+    public static String CQL2 =
+            "    CREATE TABLE blog.users (\n" +
+                    "        user_name varchar PRIMARY KEY,\n" +
+                    "        password varchar,\n" +
+                    "        gender varchar,\n" +
+                    "        state varchar,\n" +
+                    "        birth_year bigint\n" +
+                    "    );";
+
+    public static String CQL3 = "CREATE TABLE IF NOT EXISTS test.wide ( key text, key2 text, val text, PRIMARY KEY (key, key2));";
+    public static String CQL4 = "CREATE TABLE collections (key1 varchar, listval list<text>, mapval map<text, text>, setval set<text>, PRIMARY KEY (key1))";
 
     private static File copyResource(String name) throws Exception {
         InputStream is = URLClassLoader.getSystemResourceAsStream(name);


### PR DESCRIPTION
Initial commit of a 'cqlsh'-like mode for selecting data from sstable(s).

Via [jline2](https://github.com/jline/jline2), supports history maintained between sessions.

Note: History doesn't work with IntelliJ, IntelliJ also repeats whatever you input, better to use a terminal window to test this out.

Usage:

```
Offline CQL Shell for Apache Cassandra 3.x
Options:
  -f <arg> Execute commands from FILE, then exit.
  -s <arg> Schema file to use.
```

Example usage and output:

```
$ java -jar target/sstable-tools-3.0.0-SNAPSHOT.jar cqlsh ma-1-big-Data.db -s schema.cql
cqlsh> select * from sstable where ticker in ('YHOO') and date > '2016-02-01';
 ┌─────────┬─────────────────────┬────────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
 │ticker   │date                 │adj_close   │close    │high     │low      │open     │volume   │
 ╞═════════╪═════════════════════╪════════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
 │YHOO     │2016-02-19 00:00-0600│30.040001   │30.040001│30.23    │29.700001│30.190001│20706100 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-18 00:00-0600│29.42       │29.42    │30.139999│29.389999│29.559999│15259400 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-17 00:00-0600│29.370001   │29.370001│29.66    │29.059999│29.469999│12891600 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-16 00:00-0600│29.280001   │29.280001│29.440001│27.940001│27.98    │20127300 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-12 00:00-0600│27.040001   │27.040001│27.32    │26.719999│27.120001│12986200 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-11 00:00-0600│26.76       │26.76    │26.969999│26.15    │26.459999│11154900 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-10 00:00-0600│27.10       │27.10    │27.809999│26.84    │27.110001│8933600  │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-09 00:00-0600│26.82       │26.82    │27.690001│26.51    │26.639999│13919100 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-08 00:00-0600│27.049999   │27.049999│27.969999│26.48    │27.610001│24473600 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-05 00:00-0600│27.969999   │27.969999│29.139999│27.73    │29.059999│16077500 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-04 00:00-0600│29.15       │29.15    │29.23    │27.709999│27.91    │28517000 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-03 00:00-0600│27.68       │27.68    │28.610001│26.57    │28.450001│55527600 │
 ├─────────┼─────────────────────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
 │YHOO     │2016-02-02 00:00-0600│29.059999   │29.059999│30.23    │28.129999│29.32    │34022500 │
 └─────────┴─────────────────────┴────────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
cqlsh> exit;
$
```

**TODO**
1. Find out why we are leaking refs in SSTableReader (`LEAK DETECTED: a reference (org.apache.cassandra.utils.concurrent.Ref$State@6b25a2cc) to class org.apache.cassandra.io.sstable.format.SSTableReader$InstanceTidier@1601791084:/Users/atolbert/Documents/Projects/sstable-tools/ma-1-big was not released before the reference was garbage collected`)
2. ~~Add 'USE' command to switch active sstable.~~ (Done, @clohfink)
3. ~~Log number of rows.~~ (Done, @tolbertam)
4. ~~'help' command support~~ (Done, @clohfink)
5. ~~Row paging.~~ (Done, @tolbertam)
6. ~~Tab completion~~ (Done, @clohfink)
7. ~~Allow select \* from 'sstablepath' to override active sstable for particular query.~~ (Done, @clohfink)
8. ~~Allow 'USE' on a directory to involve all sstables or multiple ones?~~ (Done, @clohfink)
9. ~~Command to import schema from file~~ (Done, @tolbertam)
10. ~~Persist state (used sstable(s), active schema, paging)~~ (Done, @tolbertam)
11. ~~Implement paging for dump command.~~ (Done, @tolbertam)
12. ~~Progress bars for describe on large table~~ (Done, @clohfink)
