### PR TITLE
[#59] Include row level deletion in tombstone count

### DIFF
--- a/src/main/java/com/csforge/sstable/CassandraUtils.java
+++ b/src/main/java/com/csforge/sstable/CassandraUtils.java
@@ -381,6 +381,10 @@ public class CassandraUtils {
                         case ROW:
                             rowCount++;
                             Row row = (Row) unfiltered;
+                            if (!row.deletion().isLive()) {
+                                tombstoneCount++;
+                                ptombcount++;
+                            }
                             psize += row.dataSize();
                             pcount++;
                             for (Cell cell : row.cells()) {


### PR DESCRIPTION
Per #59, it appears that row level deletions are not considered in tombstone count.  This fixes this issue.