### PR TITLE
[#61] Automate artifact upload to github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # SSTable Tools
 
-[![Build Status](https://travis-ci.org/tolbertam/sstable-tools.svg?branch=master)](https://travis-ci.org/tolbertam/sstable-tools) [![Github Releases (by Release)](https://img.shields.io/github/downloads/tolbertam/sstable-tools/v3.9.0-alpha9/total.svg)](https://github.com/tolbertam/sstable-tools/releases/tag/v3.9.0-alpha9)
+[![Build Status](https://travis-ci.org/tolbertam/sstable-tools.svg?branch=master)](https://travis-ci.org/tolbertam/sstable-tools) [![Github Releases (by Release)](https://img.shields.io/github/downloads/tolbertam/sstable-tools/v3.11.0-alpha10/total.svg)](https://github.com/tolbertam/sstable-tools/releases/tag/v3.11.0-alpha10)
 
 A toolkit for parsing, creating and doing other fun stuff with Cassandra 3.x SSTables. This project is under development and not yet stable. Mainly a proof of concept playground for wish items.
 
 Pre compiled binary available:
 
-* [sstable-tools-3.9.0-alpha9.jar](https://github.com/tolbertam/sstable-tools/releases/download/v3.9.0-alpha9/sstable-tools-3.9.0-alpha9.jar) -  Supports 3.0 to 3.9 (ma, mb and mc sstable formats)
+* [sstable-tools-3.11.0-alpha10.jar](https://github.com/tolbertam/sstable-tools/releases/download/v3.11.0-alpha10/sstable-tools-3.11.0-alpha10.jar) -  Supports 3.0 to 3.11 (ma, mb and mc sstable formats)
 
 **Note:** This tool formerly included a `tojson` command which dumped SSTable contents to JSON.  This functionality has
 since been merged into Cassandra starting with versions 3.0.4 and 3.4 as the `sstabledump` command.

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
               <prerelease>false</prerelease>
               <draft>true</draft>
               <repositoryId>tolbertam/sstable-tools</repositoryId>
-              <tag>${project.version}</tag>
+              <tag>v${project.version}</tag>
               <fileSets>
                 <fileSet>
                   <directory>${project.build.directory}</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
     <jackson.version>2.6.4</jackson.version>
     <jline.version>2.13</jline.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- don't deploy to maven central -->
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
   <dependencies>
     <dependency>
@@ -96,6 +98,21 @@
     </dependency>
   </dependencies>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <configuration>
+            <tagNameFormat>v@{project.version}</tagNameFormat>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+            <useReleaseProfile>false</useReleaseProfile>
+            <releaseProfiles>release</releaseProfiles>
+            <goals>deploy</goals>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -164,4 +181,82 @@
     <url>https://github.com/tolbertam/sstable-tools</url>
     <tag>HEAD</tag>
   </scm>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>de.jutzig</groupId>
+            <artifactId>github-release-plugin</artifactId>
+            <version>1.2.0</version>
+            <configuration>
+              <!-- note: this requires the following in ~/.m2/settings.xml to work:
+              <server>
+                <id>github</id>
+                <username>yourusername</username>
+                <password>yourpassword</password>
+              </server> -->
+              <prerelease>false</prerelease>
+              <draft>true</draft>
+              <repositoryId>tolbertam/sstable-tools</repositoryId>
+              <tag>${project.version}</tag>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.directory}</directory>
+                  <includes>
+                    <include>sstable-tools-${project.version}.jar</include>
+                  </includes>
+                </fileSet>
+              </fileSets>
+            </configuration>
+            <executions>
+              <execution>
+                <id>release-at-deploy</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>release</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
             <artifactId>github-release-plugin</artifactId>
             <version>1.2.0</version>
             <configuration>
-              <!-- note: this requires the following in ~/.m2/settings.xml to work:
+              <!-- note: this requires the following under <servers> in ~/.m2/settings.xml to work:
               <server>
                 <id>github</id>
                 <username>yourusername</username>


### PR DESCRIPTION
Uses maven-release-plugin and github-release-plugin to deploy executable
jar to github releases on release.

To be done after #62