### PR TITLE
[#65] Add --grace_grace_seconds (-g) option to describe

### DIFF
--- a/src/main/java/com/csforge/sstable/CassandraUtils.java
+++ b/src/main/java/com/csforge/sstable/CassandraUtils.java
@@ -57,7 +57,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -320,11 +319,11 @@ public class CassandraUtils {
 
     private static Options options = new Options();
 
-    private static String GC_GRACE_SECONDS_OPTION = "g";
+    private static String GCGS_KEY = "--gc_grace_seconds";
 
     static {
-        Option gcGraceOption = new Option(GC_GRACE_SECONDS_OPTION, "gc_grace_seconds", true,
-                "gc_grace_seconds value to use in estimated droppable tombstones calculation.");
+        Option gcGraceOption = new Option(null, GCGS_KEY, true,
+                "The " + GCGS_KEY + " to use when calculating droppable tombstones");
         gcGraceOption.setRequired(false);
 
         Option helpOption = new Option("h", "help", false, "Displays this help message.");
@@ -361,7 +360,7 @@ public class CassandraUtils {
             printDescribeHelpAndExit();
         }
 
-        String gcGraceStr = cmd.getOptionValue(GC_GRACE_SECONDS_OPTION);
+        String gcGraceStr = cmd.getOptionValue(GCGS_KEY);
         final int gcGraceSeconds = gcGraceStr != null ? Integer.parseInt(gcGraceStr) : 0;
 
         boolean color = console == null || console.getTerminal().isAnsiSupported();

--- a/src/main/java/com/csforge/sstable/CassandraUtils.java
+++ b/src/main/java/com/csforge/sstable/CassandraUtils.java
@@ -319,7 +319,7 @@ public class CassandraUtils {
 
     private static Options options = new Options();
 
-    private static String GCGS_KEY = "--gc_grace_seconds";
+    private static String GCGS_KEY = "gc_grace_seconds";
 
     static {
         Option gcGraceOption = new Option(null, GCGS_KEY, true,

--- a/src/main/java/com/csforge/sstable/CassandraUtils.java
+++ b/src/main/java/com/csforge/sstable/CassandraUtils.java
@@ -35,6 +35,13 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.*;
 import org.apache.cassandra.schema.*;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.PosixParser;
 import org.joda.time.Duration;
 import org.joda.time.format.PeriodFormat;
 import org.slf4j.Logger;
@@ -311,11 +318,52 @@ public class CassandraUtils {
 
     private static Comparator<ValuedByteBuffer> VCOMP = Comparator.comparingLong(ValuedByteBuffer::getValue).reversed();
 
-    public static void printStats(String fname, PrintStream out) throws IOException, NoSuchFieldException, IllegalAccessException {
-        printStats(fname, out, null);
+    private static Options options = new Options();
+
+    private static String GC_GRACE_SECONDS_OPTION = "g";
+
+    static {
+        Option gcGraceOption = new Option(GC_GRACE_SECONDS_OPTION, "gc_grace_seconds", true,
+                "gc_grace_seconds value to use in estimated droppable tombstones calculation.");
+        gcGraceOption.setRequired(false);
+
+        Option helpOption = new Option("h", "help", false, "Displays this help message.");
+        options.addOption(gcGraceOption);
+        options.addOption(helpOption);
     }
 
-    public static void printStats(String fname, PrintStream out, ConsoleReader console) throws IOException, NoSuchFieldException, IllegalAccessException {
+    private static void printDescribeHelpAndExit() {
+        try (PrintWriter errWriter = new PrintWriter(System.err, true)) {
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp(errWriter, 120, "cqlsh describe",
+                    String.format("%nSSTable describe for Apache Cassandra 3.x%nOptions:"),
+                    options, 2, 1, "", true);
+        } finally {
+            System.exit(-1);
+        }
+    }
+
+    public static void printStats(String fname, PrintStream out, String... args) throws IOException, NoSuchFieldException, IllegalAccessException {
+        printStats(fname, out, null, args);
+    }
+
+    public static void printStats(String fname, PrintStream out, ConsoleReader console, String... args) throws IOException, NoSuchFieldException, IllegalAccessException {
+        CommandLineParser parser = new PosixParser();
+        CommandLine cmd = null;
+        try {
+            cmd = parser.parse(options, args);
+        } catch (ParseException e) {
+            System.err.format("%sFailure parsing arguments: %s%s%n%n", ANSI_RED, e.getMessage(), ANSI_RESET);
+            printDescribeHelpAndExit();
+        }
+
+        if (cmd.hasOption("h")) {
+            printDescribeHelpAndExit();
+        }
+
+        String gcGraceStr = cmd.getOptionValue(GC_GRACE_SECONDS_OPTION);
+        final int gcGraceSeconds = gcGraceStr != null ? Integer.parseInt(gcGraceStr) : 0;
+
         boolean color = console == null || console.getTerminal().isAnsiSupported();
         String c = color ? TableTransformer.ANSI_BLUE : "";
         String s = color ? TableTransformer.ANSI_CYAN : "";
@@ -459,7 +507,7 @@ public class CassandraUtils {
                     out.printf("%sminClustringValues%s:%s %s%n", c, s, r, Arrays.toString(minValues));
                     out.printf("%smaxClustringValues%s:%s %s%n", c, s, r, Arrays.toString(maxValues));
                 }
-                out.printf("%sEstimated droppable tombstones%s:%s %s%n", c, s, r, stats.getEstimatedDroppableTombstoneRatio((int) (System.currentTimeMillis() / 1000)));
+                out.printf("%sEstimated droppable tombstones%s:%s %s%n", c, s, r, stats.getEstimatedDroppableTombstoneRatio((int) (System.currentTimeMillis() / 1000) - gcGraceSeconds));
                 out.printf("%sSSTable Level%s:%s %d%n", c, s, r, stats.sstableLevel);
                 out.printf("%sRepaired at%s:%s %d %s%n", c, s, r, stats.repairedAt, toDateString(stats.repairedAt, TimeUnit.MILLISECONDS, color));
                 out.printf("%sReplay positions covered%s:%s %s%n", c, s, r, stats.commitLogIntervals);
@@ -469,7 +517,10 @@ public class CassandraUtils {
 
                 TermHistogram estDropped = new TermHistogram(stats.estimatedTombstoneDropTime.getAsMap(),
                         "Drop Time",
-                        offset -> String.format("%d %s", offset, toDateString(offset, TimeUnit.SECONDS, color)),
+                        offset -> {
+                            long dropTime = offset + gcGraceSeconds;
+                            return String.format("%d %s", dropTime, toDateString(dropTime, TimeUnit.SECONDS, color));
+                        },
                         Object::toString);
                 estDropped.printHistogram(out, color, true);
                 out.printf("%sPartition Size%s:%s%n", c, s, r);

--- a/src/main/java/com/csforge/sstable/Driver.java
+++ b/src/main/java/com/csforge/sstable/Driver.java
@@ -28,7 +28,11 @@ public class Driver {
                     System.out.println("\u001B[1;34m" + path);
                     System.out.println(TableTransformer.ANSI_CYAN + Strings.repeat("=", path.length()));
                     System.out.print(TableTransformer.ANSI_RESET);
-                    CassandraUtils.printStats(path, System.out);
+                    if (args.length > 2) {
+                        CassandraUtils.printStats(path, System.out, Arrays.copyOfRange(args, 2, args.length));
+                    } else {
+                        CassandraUtils.printStats(path, System.out);
+                    }
                 } catch (Exception e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Closes #65

Example:

without gc_grace_seconds passed in, simply only accounts for time of deletion:

```
Estimated droppable tombstones: 2.0
Estimated tombstone drop times:
   Drop Time                        | Count  (%)  Histogram 
   1500414744 (07/18/2017 16:52:24) |     1 ( 50) ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉
   1500414751 (07/18/2017 16:52:31) |     1 ( 50) ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉
   Percentiles
   50th      1663415872 (09/17/2022 06:57:52)
   75th      1663415872 (09/17/2022 06:57:52)
   95th      1663415872 (09/17/2022 06:57:52)
   98th      1663415872 (09/17/2022 06:57:52)
   99th      1663415872 (09/17/2022 06:57:52)
   Min       1386179894 (12/04/2013 11:58:14)
   Max       1663415872 (09/17/2022 06:57:52)
```

With gc_grace_seconds provided (864000, 10 days):

```
Estimated droppable tombstones: 0.0
Estimated tombstone drop times:
   Drop Time                        | Count  (%)  Histogram 
   1501278744 (07/28/2017 16:52:24) |     1 ( 50) ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉
   1501278751 (07/28/2017 16:52:31) |     1 ( 50) ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉
   Percentiles
   50th      1664279872 (09/27/2022 06:57:52)
   75th      1664279872 (09/27/2022 06:57:52)
   95th      1664279872 (09/27/2022 06:57:52)
   98th      1664279872 (09/27/2022 06:57:52)
   99th      1664279872 (09/27/2022 06:57:52)
   Min       1387043894 (12/14/2013 11:58:14)
   Max       1664279872 (09/27/2022 06:57:52)
```

One odd thing to me is that the percentiles don't really seem to make sense.  Could just be that the data set is really small here (2 deletes) so it doesn't have enough data to be meaningful?